### PR TITLE
Freifunk Castrop-Rauxel is now a member of Freifunk Ostvest e.V.

### DIFF
--- a/castrop.json
+++ b/castrop.json
@@ -1,69 +1,46 @@
 {
   "name": "Freifunk Castrop-Rauxel",
-  "url": "http://freifunk-ruhrgebiet.de",
+  "url": "http://freifunk-ostvest.de",
   "location": {
     "city": "Castrop-Rauxel",
     "country": "DE",
     "lat": 51.570920,
     "lon": 7.307838,
     "address": {
-      "Name": "foobar e.V.",
-      "Street": "Sibyllastr. 9",
-      "Zipcode": "45136"
+      "Name": "Freifunk Ostvest e.V.",
+      "Street": "Mahlerstraße 46",
+      "Zipcode": "45711"
     }
   },
   "contact": {
-    "facebook": "https://www.facebook.com/freifunk.ruhrgebiet",
-    "email": "kontakt@freifunk-ruhrgebiet.de",
-    "irc": "irc://irc.freenode.net/ffruhr",
-    "ml": "ffrl@mailman.freifunk-rheinland.net",
-    "twitter": "@ffruhr"
+    "facebook": "https://www.facebook.com/freifunk.ostvest.de/",
+    "phone": "+49236325933730",
+    "email": "info@freifunk-ostvest.de",
+    "twitter": "@FFOstvest"
   },
-  "metacommunity": "Freifunk Ruhrgebiet",
+  "metacommunity": "Freifunk Ostvest e.V.",
   "state": {
     "nodes": 15,
     "focus": [
       "infrastructure/backbone",
       "Public Free Wifi",
-      "Social Community Building",
-      "Local services and content",
       "Free internet access"
     ],
-    "lastchange": "2014-12-20T16:10:27.740Z"
+    "lastchange": "2019-08-29T20:56:01.917Z"
   },
-  "feeds": [
-    {
-      "name": "EventsFeed",
-      "category": "others",
-      "type": "xml",
-      "url": "https://freifunk-rheinland.net/?plugin=all-in-one-event-calendar&controller=ai1ec_exporter_controller&action=export_events&cb=113863465"
-    }
-  ],
   "nodeMaps": [
     {
-      "url": "http://map.freifunk-ruhrgebiet.de/graph.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "structural"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/geomap.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
+      "url": "https://karte.freifunk-ostvest.de/map/",
+      "interval": "5",
+      "technicalType": "meshviewer",
       "mapType": "geographical"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/list.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "list/status"
     }
   ],
   "techDetails": {
     "firmware": {
       "name": "gluon",
-      "url": "http://images.freifunk-ruhrgebiet.de",
-      "docs": "http://freifunk-ruhrgebiet.de/anleitung/"
+      "url": "http://images.freifunk-ostvest.de/",
+      "vpnaccess": "fwimage"
     },
     "dns": [
       {
@@ -92,5 +69,5 @@
       "institutions"
     ]
   },
-  "api": "0.4.1"
+  "api": "0.4.14"
 }


### PR DESCRIPTION
To not block other PRs this change has been moved to a separate branch.