### PR TITLE
Update existing and linked API files of Freifunk Münsterland

### DIFF
--- a/bottrop.json
+++ b/bottrop.json
@@ -1,96 +1,45 @@
 {
   "name": "Freifunk Bottrop",
-  "url": "http://freifunk-ruhrgebiet.de",
+  "url": "http://freifunk-bottrop.de",
   "location": {
     "city": "Bottrop",
     "country": "DE",
     "lat": 51.528564,
-    "lon": 6.927181,
-    "address": {
-      "Name": "foobar e.V.",
-      "Street": "Sibyllastr. 9",
-      "Zipcode": "45136"
-    }
+    "lon": 6.927181
   },
   "contact": {
-    "facebook": "https://www.facebook.com/freifunk.ruhrgebiet",
-    "email": "kontakt@freifunk-ruhrgebiet.de",
-    "irc": "irc://irc.freenode.net/ffruhr",
-    "ml": "ffrl@mailman.freifunk-rheinland.net",
-    "twitter": "@ffruhr"
+    "email": "info@freifunk-bottrop.de"
   },
-  "metacommunity": "Freifunk Ruhrgebiet",
+  "metacommunity": "Freifunk Muensterland",
   "state": {
-    "nodes": 15,
     "focus": [
-      "infrastructure/backbone",
       "Public Free Wifi",
       "Social Community Building",
-      "Local services and content",
       "Free internet access"
     ],
-    "lastchange": "2014-12-20T16:10:27.740Z"
+    "lastchange": "2019-10-21T07:10:00.000Z"
   },
-  "feeds": [
-    {
-      "name": "EventsFeed",
-      "category": "others",
-      "type": "xml",
-      "url": "https://freifunk-rheinland.net/?plugin=all-in-one-event-calendar&controller=ai1ec_exporter_controller&action=export_events&cb=113863465"
-    }
-  ],
   "nodeMaps": [
     {
-      "url": "http://map.freifunk-ruhrgebiet.de/graph.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "structural"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/geomap.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "geographical"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/list.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "list/status"
+      "url": "https://karte.freifunk-muensterland.de/map66/",
+      "interval": "1x pro Minute",
+      "technicalType": "ffmap"
     }
   ],
   "techDetails": {
     "firmware": {
       "name": "gluon",
-      "url": "http://images.freifunk-ruhrgebiet.de",
-      "docs": "http://freifunk-ruhrgebiet.de/anleitung/"
-    },
-    "dns": [
-      {
-        "domainname": "ffrg",
-        "nameserver": [
-          "10.105.0.1",
-          "10.105.8.1"
-        ]
-      }
-    ],
-    "networks": {
-      "ipv4": [
-        {
-          "network": "10.105.0.0/16"
-        }
-      ]
+      "url": "https://firmware.freifunk-muensterland.de/md-fw-dl/",
+      "docs": "https://freifunk-muensterland.de/mitmachen/anleitung/"
     },
     "routing": [
-      "batman-adv",
-      "OLSRv2"
+      "batman-adv"
     ],
     "updatemode": [
+      "manual",
       "autoupdate"
     ],
-    "legals": [
-      "institutions"
-    ]
+    "legals": []
   },
-  "api": "0.4.1"
+  "api": "0.4.14"
 }

--- a/dorsten.json
+++ b/dorsten.json
@@ -1,96 +1,45 @@
 {
   "name": "Freifunk Dorsten",
-  "url": "http://freifunk-ruhrgebiet.de",
+  "url": "https://freifunk-emscherland.de/communities/dorsten/",
   "location": {
     "city": "Dorsten",
     "country": "DE",
     "lat": 51.6605,
-    "lon": 6.9649,
-    "address": {
-      "Name": "foobar e.V.",
-      "Street": "Sibyllastr. 9",
-      "Zipcode": "45136"
-    }
+    "lon": 6.9649
   },
   "contact": {
-    "facebook": "https://www.facebook.com/freifunk.ruhrgebiet",
-    "email": "kontakt@freifunk-ruhrgebiet.de",
-    "irc": "irc://irc.freenode.net/ffruhr",
-    "ml": "ffrl@mailman.freifunk-rheinland.net",
-    "twitter": "@ffruhr"
+    "email": "dorsten@freifunk-emscherland.de"
   },
-  "metacommunity": "Freifunk Ruhrgebiet",
+  "metacommunity": "Freifunk Muensterland",
   "state": {
-    "nodes": 15,
     "focus": [
-      "infrastructure/backbone",
       "Public Free Wifi",
       "Social Community Building",
-      "Local services and content",
       "Free internet access"
     ],
-    "lastchange": "2014-12-20T16:10:27.740Z"
+    "lastchange": "2019-10-21T07:10:00.000Z"
   },
-  "feeds": [
-    {
-      "name": "EventsFeed",
-      "category": "others",
-      "type": "xml",
-      "url": "https://freifunk-rheinland.net/?plugin=all-in-one-event-calendar&controller=ai1ec_exporter_controller&action=export_events&cb=113863465"
-    }
-  ],
   "nodeMaps": [
     {
-      "url": "http://map.freifunk-ruhrgebiet.de/graph.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "structural"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/geomap.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "geographical"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/list.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "list/status"
+      "url": "https://karte.freifunk-muensterland.de/map67/",
+      "interval": "1x pro Minute",
+      "technicalType": "ffmap"
     }
   ],
   "techDetails": {
     "firmware": {
       "name": "gluon",
-      "url": "http://images.freifunk-ruhrgebiet.de",
-      "docs": "http://freifunk-ruhrgebiet.de/anleitung/"
-    },
-    "dns": [
-      {
-        "domainname": "ffrg",
-        "nameserver": [
-          "10.105.0.1",
-          "10.105.8.1"
-        ]
-      }
-    ],
-    "networks": {
-      "ipv4": [
-        {
-          "network": "10.105.0.0/16"
-        }
-      ]
+      "url": "https://firmware.freifunk-muensterland.de/md-fw-dl/",
+      "docs": "https://freifunk-muensterland.de/mitmachen/anleitung/"
     },
     "routing": [
-      "batman-adv",
-      "OLSRv2"
+      "batman-adv"
     ],
     "updatemode": [
+      "manual",
       "autoupdate"
     ],
-    "legals": [
-      "institutions"
-    ]
+    "legals": []
   },
-  "api": "0.4.1"
+  "api": "0.4.14"
 }

--- a/gladbeck.json
+++ b/gladbeck.json
@@ -1,91 +1,42 @@
 {
   "name": "Freifunk Gladbeck",
-  "url": "http://freifunk-ruhrgebiet.de",
+  "url": "https://freifunk-emscherland.de/communities/gladbeck/",
   "location": {
     "city": "Gladbeck",
     "country": "DE",
     "lat": 51.575937,
-    "lon": 6.983551,
-    "address": {
-      "Name": "foobar e.V.",
-      "Street": "Sibyllastr. 9",
-      "Zipcode": "45136"
-    }
+    "lon": 6.983551
   },
   "contact": {
-    "facebook": "https://www.facebook.com/freifunk.ruhrgebiet",
-    "email": "kontakt@freifunk-ruhrgebiet.de",
-    "irc": "irc://irc.freenode.net/ffruhr",
-    "ml": "ffrl@mailman.freifunk-rheinland.net",
-    "twitter": "@ffruhr"
+    "email": "Gladbeck@freifunk-emscherland.de"
   },
-  "metacommunity": "Freifunk Ruhrgebiet",
+  "metacommunity": "Freifunk Muensterland",
   "state": {
-    "nodes": 15,
     "focus": [
-      "infrastructure/backbone",
       "Public Free Wifi",
       "Social Community Building",
-      "Local services and content",
       "Free internet access"
     ],
-    "lastchange": "2014-12-20T16:10:27.740Z"
+    "lastchange": "2019-10-21T07:10:00.000Z"
   },
-  "feeds": [
-    {
-      "name": "EventsFeed",
-      "category": "others",
-      "type": "xml",
-      "url": "https://freifunk-rheinland.net/?plugin=all-in-one-event-calendar&controller=ai1ec_exporter_controller&action=export_events&cb=113863465"
-    }
-  ],
   "nodeMaps": [
     {
-      "url": "http://map.freifunk-ruhrgebiet.de/graph.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "structural"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/geomap.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "geographical"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/list.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "list/status"
+      "url": "https://karte.freifunk-muensterland.de/map69/",
+      "interval": "1x pro Minute",
+      "technicalType": "ffmap"
     }
   ],
   "techDetails": {
     "firmware": {
       "name": "gluon",
-      "url": "http://images.freifunk-ruhrgebiet.de",
-      "docs": "http://freifunk-ruhrgebiet.de/anleitung/"
-    },
-    "dns": [
-      {
-        "domainname": "ffrg",
-        "nameserver": [
-          "10.105.0.1",
-          "10.105.8.1"
-        ]
-      }
-    ],
-    "networks": {
-      "ipv4": [
-        {
-          "network": "10.105.0.0/16"
-        }
-      ]
+      "url": "https://firmware.freifunk-muensterland.de/md-fw-dl/",
+      "docs": "https://freifunk-muensterland.de/mitmachen/anleitung/"
     },
     "routing": [
-      "batman-adv",
-      "OLSRv2"
+      "batman-adv"
     ],
     "updatemode": [
+      "manual",
       "autoupdate"
     ],
     "legals": [

--- a/herne.json
+++ b/herne.json
@@ -1,96 +1,45 @@
 {
   "name": "Freifunk Herne",
-  "url": "http://freifunk-ruhrgebiet.de",
+  "url": "http://www.freifunk-herne.de/",
   "location": {
     "city": "Herne",
     "country": "DE",
     "lat": 51.539825,
-    "lon": 7.227286,
-    "address": {
-      "Name": "foobar e.V.",
-      "Street": "Sibyllastr. 9",
-      "Zipcode": "45136"
-    }
+    "lon": 7.227286
   },
   "contact": {
-    "facebook": "https://www.facebook.com/freifunk.ruhrgebiet",
-    "email": "kontakt@freifunk-ruhrgebiet.de",
-    "irc": "irc://irc.freenode.net/ffruhr",
-    "ml": "ffrl@mailman.freifunk-rheinland.net",
-    "twitter": "@ffruhr"
+    "email": "info@freifunk-herne.de"
   },
-  "metacommunity": "Freifunk Ruhrgebiet",
+  "metacommunity": "Freifunk Muensterland",
   "state": {
-    "nodes": 15,
     "focus": [
-      "infrastructure/backbone",
       "Public Free Wifi",
       "Social Community Building",
-      "Local services and content",
       "Free internet access"
     ],
-    "lastchange": "2014-12-20T16:10:27.740Z"
+    "lastchange": "2019-10-21T07:10:00.000Z"
   },
-  "feeds": [
-    {
-      "name": "EventsFeed",
-      "category": "others",
-      "type": "xml",
-      "url": "https://freifunk-rheinland.net/?plugin=all-in-one-event-calendar&controller=ai1ec_exporter_controller&action=export_events&cb=113863465"
-    }
-  ],
   "nodeMaps": [
     {
-      "url": "http://map.freifunk-ruhrgebiet.de/graph.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "structural"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/geomap.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "geographical"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/list.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "list/status"
+      "url": "https://karte.freifunk-muensterland.de/map76/",
+      "interval": "1x pro Minute",
+      "technicalType": "ffmap"
     }
   ],
   "techDetails": {
     "firmware": {
       "name": "gluon",
-      "url": "http://images.freifunk-ruhrgebiet.de",
-      "docs": "http://freifunk-ruhrgebiet.de/anleitung/"
-    },
-    "dns": [
-      {
-        "domainname": "ffrg",
-        "nameserver": [
-          "10.105.0.1",
-          "10.105.8.1"
-        ]
-      }
-    ],
-    "networks": {
-      "ipv4": [
-        {
-          "network": "10.105.0.0/16"
-        }
-      ]
+      "url": "https://firmware.freifunk-muensterland.de/md-fw-dl/",
+      "docs": "https://freifunk-muensterland.de/mitmachen/anleitung/"
     },
     "routing": [
-      "batman-adv",
-      "OLSRv2"
+      "batman-adv"
     ],
     "updatemode": [
+      "manual",
       "autoupdate"
     ],
-    "legals": [
-      "institutions"
-    ]
+    "legals": []
   },
-  "api": "0.4.1"
+  "api": "0.4.14"
 }

--- a/herten.json
+++ b/herten.json
@@ -1,96 +1,45 @@
 {
   "name": "Freifunk Herten",
-  "url": "http://freifunk-ruhrgebiet.de",
+  "url": "https://freifunk-emscherland.de/communities/herten/",
   "location": {
     "city": "Herten",
     "country": "DE",
     "lat": 51.60887,
-    "lon": 7.144527,
-    "address": {
-      "Name": "foobar e.V.",
-      "Street": "Sibyllastr. 9",
-      "Zipcode": "45136"
-    }
+    "lon": 7.144527
   },
   "contact": {
-    "facebook": "https://www.facebook.com/freifunk.ruhrgebiet",
-    "email": "kontakt@freifunk-ruhrgebiet.de",
-    "irc": "irc://irc.freenode.net/ffruhr",
-    "ml": "ffrl@mailman.freifunk-rheinland.net",
-    "twitter": "@ffruhr"
+    "email": "herten@freifunk-emscherland.de"
   },
-  "metacommunity": "Freifunk Ruhrgebiet",
+  "metacommunity": "Freifunk Muensterland",
   "state": {
-    "nodes": 15,
     "focus": [
-      "infrastructure/backbone",
       "Public Free Wifi",
       "Social Community Building",
-      "Local services and content",
       "Free internet access"
     ],
-    "lastchange": "2014-12-20T16:10:27.740Z"
+    "lastchange": "2019-10-21T07:10:00.000Z"
   },
-  "feeds": [
-    {
-      "name": "EventsFeed",
-      "category": "others",
-      "type": "xml",
-      "url": "https://freifunk-rheinland.net/?plugin=all-in-one-event-calendar&controller=ai1ec_exporter_controller&action=export_events&cb=113863465"
-    }
-  ],
   "nodeMaps": [
     {
-      "url": "http://map.freifunk-ruhrgebiet.de/graph.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "structural"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/geomap.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "geographical"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/list.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "list/status"
+      "url": "https://karte.freifunk-muensterland.de/map71/",
+      "interval": "1x pro Minute",
+      "technicalType": "ffmap"
     }
   ],
   "techDetails": {
     "firmware": {
       "name": "gluon",
-      "url": "http://images.freifunk-ruhrgebiet.de",
-      "docs": "http://freifunk-ruhrgebiet.de/anleitung/"
-    },
-    "dns": [
-      {
-        "domainname": "ffrg",
-        "nameserver": [
-          "10.105.0.1",
-          "10.105.8.1"
-        ]
-      }
-    ],
-    "networks": {
-      "ipv4": [
-        {
-          "network": "10.105.0.0/16"
-        }
-      ]
+      "url": "https://firmware.freifunk-muensterland.de/md-fw-dl/",
+      "docs": "https://freifunk-muensterland.de/mitmachen/anleitung/"
     },
     "routing": [
-      "batman-adv",
-      "OLSRv2"
+      "batman-adv"
     ],
     "updatemode": [
+      "manual",
       "autoupdate"
     ],
-    "legals": [
-      "institutions"
-    ]
+    "legals": []
   },
-  "api": "0.4.1"
+  "api": "0.4.14"
 }

--- a/raesfeld.json
+++ b/raesfeld.json
@@ -1,93 +1,36 @@
 {
   "name": "Freifunk Raesfeld",
-  "url": "http://freifunk-ruhrgebiet.de",
+  "url": "https://freifunk-emscherland.de/communities/raesfeld/",
   "location": {
     "city": "Raesfeld",
     "country": "DE",
     "lat": 51.775421,
-    "lon": 6.835789,
-    "address": {
-      "Name": "foobar e.V.",
-      "Street": "Sibyllastr. 9",
-      "Zipcode": "45136"
-    }
+    "lon": 6.835789
   },
   "contact": {
-    "email": "kontakt@freifunk-ruhrgebiet.de",
-    "irc": "irc://irc.freenode.net/ffruhr",
-    "ml": "ffrl@mailman.freifunk-rheinland.net",
-    "facebook": "https://www.facebook.com/freifunk.ruhrgebiet",
-    "twitter": "@ffruhr"
+    "email": "raesfeld@freifunk-emscherland.de"
   },
-  "metacommunity": "Freifunk Ruhrgebiet",
+  "metacommunity": "Freifunk Muensterland",
   "state": {
-    "nodes": 15,
     "focus": [
-      "infrastructure/backbone",
       "Public Free Wifi",
       "Social Community Building",
-      "Local services and content",
       "Free internet access"
     ],
-    "lastchange": "2014-12-20T16:10:27.740Z"
+    "lastchange": "2019-10-21T07:10:00.000Z"
   },
-  "feeds": [
-    {
-      "name": "EventsFeed",
-      "category": "others",
-      "type": "xml",
-      "url": "https://freifunk-rheinland.net/?plugin=all-in-one-event-calendar&controller=ai1ec_exporter_controller&action=export_events&cb=113863465"
-    }
-  ],
   "nodeMaps": [
     {
-      "url": "http://map.freifunk-ruhrgebiet.de/graph.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "structural"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/geomap.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "geographical"
-    },
-    {
-      "url": "http://map.freifunk-ruhrgebiet.de/list.html",
-      "interval": "1 Minute",
-      "technicalType": "ffmap",
-      "mapType": "list/status"
+      "url": "https://karte.freifunk-muensterland.de/map73/",
+      "interval": "1x pro Minute",
+      "technicalType": "ffmap"
     }
   ],
   "techDetails": {
     "firmware": {
       "name": "gluon",
-      "url": "http://images.freifunk-ruhrgebiet.de",
-      "docs": "http://freifunk-ruhrgebiet.de/anleitung/"
-    },
-    "dns": [
-      {
-        "domainname": "ffrg",
-        "nameserver": [
-          "10.53.16.2",
-          "82.207.138.33"
-        ]
-      }
-    ],
-    "networks": {
-      "ipv6": [
-        {
-          "network": "2a02:f98:0:26::/64"
-        }
-      ],
-      "ipv4": [
-        {
-          "network": "10.105.0.0/16"
-        },
-        {
-          "network": "10.53.0.0/16"
-        }
-      ]
+      "url": "https://firmware.freifunk-muensterland.de/md-fw-dl/",
+      "docs": "https://freifunk-muensterland.de/mitmachen/anleitung/"
     },
     "routing": [
       "batman-adv"
@@ -96,10 +39,7 @@
       "manual",
       "autoupdate"
     ],
-    "legals": [
-      "vpnnational",
-      "institutions"
-    ]
+    "legals": []
   },
-  "api": "0.4.4"
+  "api": "0.4.14"
 }


### PR DESCRIPTION
Updated all API files to version 0.4.14.
Old Ruhrgebiet data removed.
Now linked to metacommunity Freifunk Münster.
Map and firmware URL updated.
E-Mail updated
Long/Lat verified.

Resolves #12